### PR TITLE
Normalization upgrade

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,8 @@ Always fork the repo and create your branch from master. If you've added code th
 
 Please follow the [TypeScript coding guidelines](https://github.com/Microsoft/TypeScript/wiki/Coding-guidelines).
 
+You should prefix all private variables with `_` sign. To prevent accidental name collisions with your code Rawmodel somes prefixes names of public objects with `$` and names of private objects with `$$`. You can find this convention in outer frameworks like [AngularJS](https://docs.angularjs.org/api).
+
 ## Release process
 
 The release manager will publish packages to NPM using these commands.

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ public name: string;
 
 ### Value Assignments
 
-Model's properties are like properties on a Javascript Object. We can easily assign a value to a property through its setter method (e.g. `model.name = 'value';`). Instead of assigning properties one by one, we can use the `populate()` method as shown below.
+Model's properties are like properties of a Javascript Object. We can easily assign a value to a property through its setter method (e.g. `model.name = 'value';`). Instead of assigning properties one by one, we can use the `populate()` method to assign values to multiple enumerable properties.
 
 ```ts
 model.populate({
@@ -213,7 +213,7 @@ It's encouraged to use the `populate()` method for assigning values unless you k
 
 ### Serialization & Filtering
 
-Model provides useful methods for object serialization and filtering. All properties are serializable by default and are thus included in the result object returned by the `serialize()` method. We can customize the output and include or exclude properties for different situations by using serialization strategies.
+Model provides useful methods for object serialization and filtering. All enumerable properties are serializable by default and are thus included in the result object returned by the `serialize()` method. We can customize the output and include or exclude properties for different situations by using serialization strategies.
 
 ```ts
 class User extends Model {
@@ -638,7 +638,7 @@ try {
 
 **Model.prototype.populate(data, strategy)**: Model
 
-> Applies data to a model.
+> Populates enumerable properties with data.
 
 | Option | Type | Required | Default | Description
 |--------|------|----------|---------|------------
@@ -655,7 +655,7 @@ try {
 
 **Model.prototype.serialize(strategy)**: Object
 
-> Converts a model into serialized data object.
+> Converts a model into serialized data object. The result will include only enumerable properties.
 
 | Option | Type | Required | Default | Description
 |--------|------|----------|---------|------------
@@ -794,7 +794,7 @@ try {
 
 **Prop.prototype.serialize(strategy)**
 
-> Returns a serialized property value.
+> Returns a serialized property value. Note that only enumerable properties are serializable.
 
 | Option | Type | Required | Default | Description
 |--------|------|----------|---------|------------

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ import { stringParser } from '@rawmodel/parsers';
 
 class User extends Model {
   @prop({
-    parse: {
+    parser: {
       resolver: stringParser(),
     },
   })
@@ -102,13 +102,13 @@ class Friend extends Model {
 
 class User extends Model {
   @prop({
-    parse: {
+    parser: {
       resolver: Address,
     },
   })
   public address: Address;
   @prop({
-    parse: {
+    parser: {
       array: true,
       resolver: Friend,
     },
@@ -162,8 +162,8 @@ A property can have a custom `getter` and a custom `setter`. This function share
 
 ```ts
 @prop({
-  get(value) { return value },
-  set(value) { return value },
+  getter(value) { return value },
+  setter(value) { return value },
 })
 public name: string;
 ```
@@ -272,7 +272,7 @@ RawModel provides a simple mechanism for validating properties. All validators s
 ```ts
 class User extends Model {
   @prop({
-    validate: [ // property validation setup
+    validators: [ // property validation setup
       { // validator recipe
         resolver(v) { return !!v }, // [required] validator function
         code: 422, // [optional] error code
@@ -295,7 +295,7 @@ RawModel provides a mechanism for handling property-related errors. The logic is
 ```ts
 class User extends Model {
   @prop({
-    handle: [ // property error handling setup
+    handlers: [ // property error handling setup
       { // handler recipe
         resolver(e) { return e.message === 'foo' }, // [required] error resolve function
         code: 31000, // [optional] error code
@@ -366,7 +366,7 @@ const schema = {
   props: [ // schema properties
     { // property definition
       name: 'title', // property name
-      validate: [
+      validators: [
         {
           resolver: 'stringLength', // validator resolver name
           code: 30001, // validation error code
@@ -418,14 +418,14 @@ graphql(schema, '{ hello }', root).then((response) => {
 | Option | Type | Required | Default | Description
 |--------|------|----------|---------|------------
 | config.$.name | String | Yes | - | Property name.
-| config.$.prop.set | Function | No | - | Custom setter.
-| config.$.prop.get | Function | No | - | Custom getter.
-| config.$.prop.parse | Parser | No | - | Data type parser (see supported types).
+| config.$.prop.setter | Function | No | - | Custom setter.
+| config.$.prop.getter | Function | No | - | Custom getter.
+| config.$.prop.parser | Parser | No | - | Data type parser (see supported types).
 | config.$.prop.defaultValue | Any | No | - | Prop default value.
 | config.$.prop.fakeValue | Any | No | - | Prop fake value.
 | config.$.prop.emptyValue | Any | No | - | Prop empty value.
-| config.$.prop.validate | Array | No | - | List of validator recipes.
-| config.$.prop.handle | Array | No | - | List of error handler recipes.
+| config.$.prop.validators | Array | No | - | List of validator recipes.
+| config.$.prop.handlers | Array | No | - | List of error handler recipes.
 | config.$.prop.populatable | String[] | No | - | List of strategies for populating the property value.
 | config.$.prop.serializable | String[] | No | - | List of strategies for serializing the property value.
 | config.$.prop.enumerable | Boolean | No | true | Indicates that the property is enumerable.
@@ -456,20 +456,20 @@ class User extends Model {
   @prop({
     set(v) { return v; }, // [optional] custom setter
     get(v) { return v; }, // [optional] custom getter
-    parse: { // [optional] property type casting
+    parser: { // [optional] property type casting
       array: true, // [optional] forces to array conversion when `true`
       resolver: User, // [optional] parser function or Model
     },
     defaultValue: 'Noname', // [optional] property default value (value or function)
     fakeValue: 'Noname', // [optional] property fake value (value or function)
     emptyValue: '', // [optional] property empty value (value or function)
-    validate: [ // [optional] value validator recipes
+    validators: [ // [optional] value validator recipes
       { // validator recipe (check validatable.js for more)
         resolver(v) { return !!v; }, // [required] validator resolve function (supports async)
         code: 422, // [optional] error code
       },
     ],
-    handle: [ // [optional] error handling recipies
+    handlers: [ // [optional] error handling recipies
       { // handler recipe
         resolver(e) { return e.message === 'foo'; }, // [required] handler resolve function (supports async)
         code: 31000, // [required] error code
@@ -489,14 +489,14 @@ class User extends Model {
 
 | Option | Type | Required | Default | Description
 |--------|------|----------|---------|------------
-| config.set | Function | No | - | Custom setter.
-| config.get | Function | No | - | Custom getter.
-| config.parse | Parser | No | - | Data type parser (see supported types).
+| config.setter | Function | No | - | Custom setter.
+| config.getter | Function | No | - | Custom getter.
+| config.parser | Parser | No | - | Data type parser (see supported types).
 | config.defaultValue | Any | No | - | Prop default value.
 | config.fakeValue | Any | No | - | Prop fake value.
 | config.emptyValue | Any | No | - | Prop empty value.
-| config.validate | Array | No | - | List of validator recipes.
-| config.handle | Array | No | - | List of error handler recipes.
+| config.validators | Array | No | - | List of validator recipes.
+| config.handlers | Array | No | - | List of error handler recipes.
 | config.populatable | String[] | No | - | List of strategies for populating the property value.
 | config.serializable | String[] | No | - | List of strategies for serializing the property value.
 | config.enumerable | Boolean | No | true | Indicates that the property is enumerable.
@@ -683,14 +683,14 @@ try {
 
 | Option | Type | Required | Default | Description
 |--------|------|----------|---------|------------
-| config.set | Function | No | - | Custom setter.
-| config.get | Function | No | - | Custom getter.
-| config.parse | Parser | No | - | Data type parser (see supported types).
+| config.setter | Function | No | - | Custom setter.
+| config.getter | Function | No | - | Custom getter.
+| config.parser | Parser | No | - | Data type parser (see supported types).
 | config.defaultValue | Any | No | - | Prop default value.
 | config.fakeValue | Any | No | - | Prop fake value.
 | config.emptyValue | Any | No | - | Prop empty value.
-| config.validate | Array | No | - | List of validator recipes.
-| config.handle | Array | No | - | List of error handler recipes.
+| config.validators | Array | No | - | List of validator recipes.
+| config.handlers | Array | No | - | List of error handler recipes.
 | config.populatable | String[] | No | - | List of strategies for populating the property value.
 | config.serializable | String[] | No | - | List of strategies for serializing the property value.
 | config.enumerable | Boolean | No | true | Indicates that the property is enumerable.
@@ -831,20 +831,20 @@ try {
 | recipe.props | Array | No | - | Hash of property definitions.
 | recipe.props.$.set | String | No | - | Setter resolver name.
 | recipe.props.$.get | String | No | - | Getter resolver name.
-| recipe.props.$.parse | Object | No | - | Data type parser recipe.
-| recipe.props.$.parse.array | Boolean | No | false | When `true` the input data will automatically be converted to array.
-| recipe.props.$.parse.resolver | String | No | - | Parser resolver name
+| recipe.props.$.parser | Object | No | - | Data type parser recipe.
+| recipe.props.$.parser.array | Boolean | No | false | When `true` the input data will automatically be converted to array.
+| recipe.props.$.parser.resolver | String | No | - | Parser resolver name
 | recipe.props.$.defaultValue | Any | No | - | Default value resolver name or a value.
 | recipe.props.$.fakeValue | Any | No | - | Fake value resolver name or a value.
 | recipe.props.$.emptyValue | Any | No | - | Empty value resolver name or a value.
-| recipe.props.$.validate | Array | No | - | List of validator recipes.
-| recipe.props.$.validate.code | Integer | Yes | - | Validator error code.
-| recipe.props.$.validate.resolver | String | Yes | - | Validator resolver name.
-| recipe.props.$.validate.options | Object | No | - | Validator resolver arguments.
-| recipe.props.$.handle | Array | No | - | List of error handler recipes.
-| recipe.props.$.handle.code | Integer | Yes | - | Handler error code.
-| recipe.props.$.handle.resolver | String | Yes | - | Handler resolver name.
-| recipe.props.$.handle.options | Object | No | - | Handler resolver arguments.
+| recipe.props.$.validators | Array | No | - | List of validator recipes.
+| recipe.props.$.validators.code | Integer | Yes | - | Validator error code.
+| recipe.props.$.validators.resolver | String | Yes | - | Validator resolver name.
+| recipe.props.$.validators.options | Object | No | - | Validator resolver arguments.
+| recipe.props.$.handlers | Array | No | - | List of error handler recipes.
+| recipe.props.$.handlers.code | Integer | Yes | - | Handler error code.
+| recipe.props.$.handlers.resolver | String | Yes | - | Handler resolver name.
+| recipe.props.$.handlers.options | Object | No | - | Handler resolver arguments.
 | recipe.props.$.populatable | Array | No | - | List of strategies for populating the property value.
 | recipe.props.$.serializable | Array | No | - | List of strategies for serializing the property value.
 | recipe.props.$.enumerable | Boolean | No | true | Indicates that the property is enumerable.
@@ -879,22 +879,22 @@ const Model = createModelClass({
   handlers: {}, // see validators
   props: [
     name: 'firstName', // property name
-    get: 'customGetter', // getter name (defined in `getters`)
-    set: 'customSetter', // setter name (defined in `setters`)
-    parse: {
+    getter: 'customGetter', // getter name (defined in `getters`)
+    setter: 'customSetter', // setter name (defined in `setters`)
+    parser: {
       array: true, // when `true` the input is converted to array
       resolver: 'toString', // parser resolver name
     },
     defaultValue: 'none', // static default value
     fakeValue: 'none', // static fake value
     emptyValue: '', // static empty value
-    validate: [
+    validators: [
       {
         code: 30001, // validator error code
         resolver: 'isPresent', // validator resolver name
       },
     ],
-    handle: [], // see validators
+    handlers: [], // see validators
     populatable: ['input', 'db'], // populatable strategies
     serializable: ['input', 'db'], // serializable strategies
     enumerable: true, // property is enumerable

--- a/README.md
+++ b/README.md
@@ -571,6 +571,10 @@ user.flatten(); // -> [{ path, prop, value }, ...]
 
 > Makes each model property not settable.
 
+**Model.prototype.getAncestors()**: Model[]
+
+> Returns a list of all parent model instances.
+
 **Model.prototype.getContext()**: Context
 
 > Returns model context data.
@@ -586,10 +590,6 @@ user.flatten(); // -> [{ path, prop, value }, ...]
 | Option | Type | Required | Default | Description
 |--------|------|----------|---------|------------
 | keys | Array | Yes | - | Path to a property (e.g. `['book', 0, 'title']`).
-
-**Model.prototype.getRoot()**: Model
-
-> Returns the first model instance in a tree of models.
 
 **Model.prototype.handle(error, { quiet }): Promise(Model)**
 

--- a/common/config/rush/npm-shrinkwrap.json
+++ b/common/config/rush/npm-shrinkwrap.json
@@ -432,9 +432,9 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "commander": {
-      "version": "2.20.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.0.tgz",
-      "integrity": "sha512-7j2y+40w61zy6YC2iRNpUe/NwhNyoXrYpHMrSunaMG64nRnaf96zO/KMQR4OyN/UnE5KLyEBnKHd4aG3rskjpQ=="
+      "version": "2.20.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.1.tgz",
+      "integrity": "sha512-cCuLsMhJeWQ/ZpsFTbE765kvVfoeSddc4nU3up4fV+fDBcfUXnbITJ+JzhkdjzOqhURjZgujxaioam4RM9yGUg=="
     },
     "commondir": {
       "version": "1.0.1",
@@ -712,9 +712,9 @@
       "integrity": "sha512-IItsdsea19BoLC7ELy13q1iJFNmd7ofZH5+X/pJr90/nRoPEX0DJo1dHDbgtYWOhJhcCgMDTOw84RZ72q6lB+Q=="
     },
     "handlebars": {
-      "version": "4.3.3",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.3.3.tgz",
-      "integrity": "sha512-VupOxR91xcGojfINrzMqrvlyYbBs39sXIrWa7YdaQWeBudOlvKEGvCczMfJPgnuwHE/zyH1M6J+IUP6cgDVyxg==",
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.4.2.tgz",
+      "integrity": "sha512-cIv17+GhL8pHHnRJzGu2wwcthL5sb8uDKBHvZ2Dtu5s1YNt0ljbzKbamnc+gr69y7bzwQiBdr5+hOpRd5pnOdg==",
       "requires": {
         "neo-async": "^2.6.0",
         "optimist": "^0.6.1",
@@ -805,9 +805,9 @@
       "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
     },
     "is-buffer": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
-      "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw=="
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+      "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
     },
     "is-extglob": {
       "version": "2.1.1",

--- a/common/config/rush/npm-shrinkwrap.json
+++ b/common/config/rush/npm-shrinkwrap.json
@@ -187,7 +187,7 @@
     },
     "@rush-temp/core": {
       "version": "file:projects/core.tgz",
-      "integrity": "sha512-Y3Yu+M7NtFvuQrduS56nWJtYVYVwoQMlb1Pqx46xxiyemS2PzszPJU1zYOxqbliCTmwpAaLPxwRF/VyLDC9e4A==",
+      "integrity": "sha512-Hpowr53NwwtGYFttUcozqZfQSlS8CFDD7DA8I0FfgSM7Gz52DyZbpIVwp8SE9dH5P/fuh7nEccqiRln5iw+LDw==",
       "requires": {
         "@hayspec/cli": "^0.8.4",
         "@hayspec/spec": "^0.8.4",
@@ -211,7 +211,7 @@
     },
     "@rush-temp/parsers": {
       "version": "file:projects/parsers.tgz",
-      "integrity": "sha512-kwYybNziTMAjb7wD9FmJpZBRdljnBnjDRTfPP0Y8A+OB6NPjvjTHvHH6V6nkuJWqpsrJYILTTzB44tFr8+XPKA==",
+      "integrity": "sha512-FEUw4ERCoIh4n94rnfLXBOWs2vb/L+b7z8Hsx+vxFnY6Wt4Lx1P+ckzFrIMSbFq/ep/2sSQztAnaYTSYFWftTg==",
       "requires": {
         "@hayspec/cli": "^0.8.4",
         "@hayspec/spec": "^0.8.4",
@@ -224,7 +224,7 @@
     },
     "@rush-temp/schema": {
       "version": "file:projects/schema.tgz",
-      "integrity": "sha512-8WVHNb7JTj09UyqngiwodGLDGGbj+kDLg/6KjZTtTaxZlRO28BEMO21YITHx6Zksf8PwqlsylkYBD4Bxa8MZsw==",
+      "integrity": "sha512-wrqE5yUeT3iP9przFcNiPOE7tbxsUGk5eEmPdoMJpSFdEt32PF2jD49TxQwULqSF+ALxOG0DfLKZtlB6UX4Fdg==",
       "requires": {
         "@hayspec/cli": "^0.8.4",
         "@hayspec/spec": "^0.8.4",
@@ -248,7 +248,7 @@
     },
     "@rush-temp/validators": {
       "version": "file:projects/validators.tgz",
-      "integrity": "sha512-qrPj9k5M+fhNKQi9cJpEN+jLXLVQTlIZGdWNslR7y8m5mroOYJ57cCyOCK59y29m/VwzK9THzsVkDF3WjTrk6w==",
+      "integrity": "sha512-nba6NdE+JmzLR58Xh5BCHX52ADBRz9nbxU64HSqOklXMdhAp4VB224y+tWYN4rGbNEeT6cge6P5wSG86IDx2ZQ==",
       "requires": {
         "@hayspec/cli": "^0.8.4",
         "@hayspec/spec": "^0.8.4",

--- a/common/config/rush/version-policies.json
+++ b/common/config/rush/version-policies.json
@@ -2,7 +2,7 @@
   {
     "policyName": "patchAll",
     "definitionName": "lockStepVersion",
-    "version": "3.2.1",
+    "version": "3.3.0",
     "nextBump": "patch"
   }
 ]

--- a/packages/rawmodel-core/CHANGELOG.json
+++ b/packages/rawmodel-core/CHANGELOG.json
@@ -2,6 +2,12 @@
   "name": "@rawmodel/core",
   "entries": [
     {
+      "version": "3.3.0",
+      "tag": "@rawmodel/core_v3.3.0",
+      "date": "Thu, 03 Oct 2019 15:49:09 GMT",
+      "comments": {}
+    },
+    {
       "version": "3.2.1",
       "tag": "@rawmodel/core_v3.2.1",
       "date": "Sun, 29 Sep 2019 10:22:42 GMT",

--- a/packages/rawmodel-core/CHANGELOG.md
+++ b/packages/rawmodel-core/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log - @rawmodel/core
 
-This log was last generated on Sun, 29 Sep 2019 10:22:42 GMT and should not be manually modified.
+This log was last generated on Thu, 03 Oct 2019 15:49:09 GMT and should not be manually modified.
+
+## 3.3.0
+Thu, 03 Oct 2019 15:49:09 GMT
+
+*Version update only*
 
 ## 3.2.1
 Sun, 29 Sep 2019 10:22:42 GMT

--- a/packages/rawmodel-core/package.json
+++ b/packages/rawmodel-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rawmodel/core",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "description": "Strongly-typed JavaScript object with support for validation and error handling.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -84,13 +84,13 @@
   "devDependencies": {
     "@hayspec/cli": "^0.8.4",
     "@hayspec/spec": "^0.8.4",
-    "@rawmodel/parsers": "3.2.1",
+    "@rawmodel/parsers": "3.3.0",
     "nyc": "^14.1.1",
     "ts-node": "^8.3.0",
     "tslint": "^5.18.0",
     "typescript": "^3.5.3"
   },
   "dependencies": {
-    "@rawmodel/utils": "3.2.1"
+    "@rawmodel/utils": "3.3.0"
   }
 }

--- a/packages/rawmodel-core/src/core/models.ts
+++ b/packages/rawmodel-core/src/core/models.ts
@@ -73,25 +73,27 @@ export class Model<Context = any> {
   /**
    * Returns parent model instance.
    */
-  public getParent() {
+  public getParent(): Model<Context> {
     return this.$config.parent || null;
   }
 
   /**
-   * Returns the root model instance.
+   * Returns a list of all parent model instances.
    */
-  public getRoot() {
-    let root: Model = this;
-    do {
-      const parent = root.getParent();
+  public getAncestors(): Model<Context>[] {
+    const tree  = [];
+
+    let parent = this as any;
+    while (true) {
+      parent = parent.getParent();
       if (parent) {
-        root = parent;
-      }
-      else {
-        return root;
+        tree.unshift(parent);
+      } else {
+        break;
       }
     }
-    while (true);
+
+    return tree;
   }
 
   /**

--- a/packages/rawmodel-core/src/core/models.ts
+++ b/packages/rawmodel-core/src/core/models.ts
@@ -7,9 +7,9 @@ import { ModelConfig, PropConfig, PropItem, PropError, PropPath } from './types'
  * Strongly typed javascript object.
  */
 export class Model<Context = any> {
-  readonly $config: ModelConfig<Context>;
-  readonly $props: {[key: string]: Prop};
-  static readonly $props: {[key: string]: PropConfig} = {};
+  public readonly $config: ModelConfig<Context>;
+  public readonly $props: {[key: string]: Prop};
+  public static readonly $props: {[key: string]: PropConfig} = {};
 
   /**
    * Class constructor.

--- a/packages/rawmodel-core/src/core/props.ts
+++ b/packages/rawmodel-core/src/core/props.ts
@@ -236,8 +236,8 @@ export class Prop {
         }
         else {
           return new Klass(null, {
+            ...this.getModel().$config,
             parent: this.getModel(),
-            ...this.getModel().$config
           }).populate(data, strategy);
         }
       };

--- a/packages/rawmodel-core/src/core/props.ts
+++ b/packages/rawmodel-core/src/core/props.ts
@@ -74,11 +74,11 @@ export class Prop {
     }
 
     let value = isUndefined(data) ? null : data;
-    if (this.$config.parse) {
+    if (this.$config.parser) {
       value = this.parse(realize(value, this.getModel()), strategy);
     }
-    if (this.$config.set) {
-      value = this.$config.set.call(this.getModel(), realize(value, this.getModel()));
+    if (this.$config.setter) {
+      value = this.$config.setter.call(this.getModel(), realize(value, this.getModel()));
     }
 
     this.rawValue = value;
@@ -90,8 +90,8 @@ export class Prop {
   public getValue(): any {
     let value = realize(this.rawValue, this.getModel());
 
-    if (this.$config.get) {
-      value = this.$config.get.call(this.getModel(), value);
+    if (this.$config.getter) {
+      value = this.$config.getter.call(this.getModel(), value);
     }
 
     if (!isPresent(value) && !isUndefined(this.$config.emptyValue)) {
@@ -133,7 +133,7 @@ export class Prop {
    * Returns `true` if the property is an array.
    */
   public isArray(): boolean {
-    const { array } = this.$config.parse || {} as any;
+    const { array } = this.$config.parser || {} as any;
     return array === true;
   }
 
@@ -219,7 +219,7 @@ export class Prop {
    * @param strategy Population strategy (only for Model types).
    */
   protected parse(value: any, strategy?: string): any {
-    const parser = (this.$config.parse || {}) as any;
+    const parser = (this.$config.parser || {}) as any;
     const recipe = {
       resolver: parser.resolver,
       array: parser.array || false,
@@ -327,7 +327,7 @@ export class Prop {
   public rollback(): this {
     let value = this.initialValue;
 
-    if (this.$config.parse) {
+    if (this.$config.parser) {
       value = this.parse(value);
     }
 
@@ -357,7 +357,7 @@ export class Prop {
 
     this.errorCode = await validate(
       this.getValue(),
-      this.$config.validate,
+      this.$config.validators,
       {
         context: this.getModel(),
       },
@@ -379,7 +379,7 @@ export class Prop {
 
     this.errorCode = await handle(
       error,
-      this.$config.handle,
+      this.$config.handlers,
       {
         context: this.getModel(),
       },

--- a/packages/rawmodel-core/src/core/props.ts
+++ b/packages/rawmodel-core/src/core/props.ts
@@ -143,8 +143,11 @@ export class Prop {
    */
   public isPopulatable(strategy?: string): boolean {
     return (
-      isUndefined(strategy)
-      || (this.$config.populatable || []).indexOf(strategy) !== -1
+      this.$config.enumerable !== false
+      && (
+        isUndefined(strategy)
+        || (this.$config.populatable || []).indexOf(strategy) !== -1
+      )
     );
   }
 
@@ -154,8 +157,11 @@ export class Prop {
    */
   public isSerializable(strategy?: string): boolean {
     return (
-      isUndefined(strategy)
-      || (this.$config.serializable || []).indexOf(strategy) !== -1
+      this.$config.enumerable !== false
+      && (
+        isUndefined(strategy)
+        || (this.$config.serializable || []).indexOf(strategy) !== -1
+      )
     );
   }
 

--- a/packages/rawmodel-core/src/core/types.ts
+++ b/packages/rawmodel-core/src/core/types.ts
@@ -35,14 +35,14 @@ export interface PropItem {
  * Model property class configuration object.
  */
 export interface PropConfig {
-  set?: SimpleResolver;
-  get?: SimpleResolver;
-  parse?: ParserRecipe;
+  getter?: SimpleResolver;
+  setter?: SimpleResolver;
+  parser?: ParserRecipe;
   defaultValue?: any | SimpleResolver;
   fakeValue?: any | SimpleResolver;
   emptyValue?: any | SimpleResolver;
-  validate?: ValidatorRecipe[];
-  handle?: HandlerRecipe[];
+  validators?: ValidatorRecipe[];
+  handlers?: HandlerRecipe[];
   populatable?: string[];
   serializable?: string[];
   enumerable?: boolean;

--- a/packages/rawmodel-core/src/tests/core/builder/create-model-class-method.test.ts
+++ b/packages/rawmodel-core/src/tests/core/builder/create-model-class-method.test.ts
@@ -15,7 +15,7 @@ spec.test('generates model with properties', (ctx) => {
     },
     {
       name: 'book',
-      parse: {
+      parser: {
         resolver: createModelClass([
           {
             name: 'title',

--- a/packages/rawmodel-core/src/tests/core/models/apply-errors-instance-method.test.ts
+++ b/packages/rawmodel-core/src/tests/core/models/apply-errors-instance-method.test.ts
@@ -12,11 +12,11 @@ spec.test('sets properties errors', (ctx) => {
     @prop()
     name: string;
     @prop({
-      parse: { resolver: Book },
+      parser: { resolver: Book },
     })
     book: Book;
     @prop({
-      parse: { array: true, resolver: Book },
+      parser: { array: true, resolver: Book },
     })
     books: Book[];
   }

--- a/packages/rawmodel-core/src/tests/core/models/clone-instance-method.test.ts
+++ b/packages/rawmodel-core/src/tests/core/models/clone-instance-method.test.ts
@@ -12,11 +12,11 @@ spec.test('returns an exact copy of the original', (ctx) => {
     @prop()
     name: string;
     @prop({
-      parse: { resolver: Book },
+      parser: { resolver: Book },
     })
     book: Book;
     @prop({
-      parse: { array: true, resolver: Book },
+      parser: { array: true, resolver: Book },
     })
     books: Book[];
   }

--- a/packages/rawmodel-core/src/tests/core/models/clone-instance-method.test.ts
+++ b/packages/rawmodel-core/src/tests/core/models/clone-instance-method.test.ts
@@ -38,9 +38,8 @@ spec.test('returns an exact copy of the original', (ctx) => {
   const clone1 = user.clone({book: { title: 'foo' }});
   ctx.true(clone0 !== user);
   ctx.true(clone0.isEqual(user));
-  ctx.is(clone0.book.getParent(), clone0);
-  ctx.is(clone0.getParent(), null);
-  ctx.is(clone0.getRoot(), clone0);
+  ctx.deepEqual(clone0.getAncestors(), []);
+  ctx.deepEqual(clone0.book.getAncestors(), [clone0]);
   ctx.is(clone1.book.title, 'foo');
 });
 

--- a/packages/rawmodel-core/src/tests/core/models/collect-errors-instance-method.test.ts
+++ b/packages/rawmodel-core/src/tests/core/models/collect-errors-instance-method.test.ts
@@ -12,11 +12,11 @@ spec.test('returns an array of errors', (ctx) => {
     @prop()
     name: string;
     @prop({
-      parse: { resolver: Book },
+      parser: { resolver: Book },
     })
     book: Book;
     @prop({
-      parse: { array: true, resolver: Book },
+      parser: { array: true, resolver: Book },
     })
     books: Book[];
   }

--- a/packages/rawmodel-core/src/tests/core/models/commit-instance-method.test.ts
+++ b/packages/rawmodel-core/src/tests/core/models/commit-instance-method.test.ts
@@ -12,11 +12,11 @@ spec.test('manage committed states', (ctx) => {
     @prop()
     name: string;
     @prop({
-      parse: { resolver: Book },
+      parser: { resolver: Book },
     })
     book: Book;
     @prop({
-      parse: { array: true, resolver: Book },
+      parser: { array: true, resolver: Book },
     })
     books: Book[];
   }

--- a/packages/rawmodel-core/src/tests/core/models/empty-instance-method.test.ts
+++ b/packages/rawmodel-core/src/tests/core/models/empty-instance-method.test.ts
@@ -20,12 +20,12 @@ spec.test('sets properties to `null`', (ctx) => {
     })
     description: string;
     @prop({
-      parse: { resolver: Book },
+      parser: { resolver: Book },
       defaultValue: {},
     })
     book: Book;
     @prop({
-      parse: { array: true, resolver: Book },
+      parser: { array: true, resolver: Book },
       defaultValue: [null, {}],
     })
     books: Book[];

--- a/packages/rawmodel-core/src/tests/core/models/fake-instance-method.test.ts
+++ b/packages/rawmodel-core/src/tests/core/models/fake-instance-method.test.ts
@@ -16,12 +16,12 @@ spec.test('sets properties to their fake values', (ctx) => {
     })
     name: string;
     @prop({
-      parse: { resolver: Book },
+      parser: { resolver: Book },
       fakeValue: 'bar',
     })
     book: Book;
     @prop({
-      parse: { array: true, resolver: Book },
+      parser: { array: true, resolver: Book },
       fakeValue: [null, {}],
     })
     books: Book[];

--- a/packages/rawmodel-core/src/tests/core/models/flatten-instance-method.test.ts
+++ b/packages/rawmodel-core/src/tests/core/models/flatten-instance-method.test.ts
@@ -12,11 +12,11 @@ spec.test('returns an array of props', (ctx) => {
     @prop()
     name: string;
     @prop({
-      parse: { resolver: Book },
+      parser: { resolver: Book },
     })
     book: Book;
     @prop({
-      parse: { array: true, resolver: Book },
+      parser: { array: true, resolver: Book },
     })
     books: Book[];
   }

--- a/packages/rawmodel-core/src/tests/core/models/freeze-instance-method.test.ts
+++ b/packages/rawmodel-core/src/tests/core/models/freeze-instance-method.test.ts
@@ -12,11 +12,11 @@ spec.test('makes property not settable', async (ctx) => {
     @prop()
     name: string;
     @prop({
-      parse: { resolver: Book },
+      parser: { resolver: Book },
     })
     book: Book;
     @prop({
-      parse: { array: true, resolver: Book },
+      parser: { array: true, resolver: Book },
     })
     books: Book[];
   }

--- a/packages/rawmodel-core/src/tests/core/models/get-ancestors-instance-method.test.ts
+++ b/packages/rawmodel-core/src/tests/core/models/get-ancestors-instance-method.test.ts
@@ -4,9 +4,17 @@ import { Model, prop } from '../../..';
 const spec = new Spec();
 
 spec.test('returns the first model in a tree of nested models', (ctx) => {
+  class Author extends Model {
+    @prop()
+    name: string;
+  }
   class Book extends Model {
     @prop()
     title: string;
+    @prop({
+      parser: { resolver: Author },
+    })
+    author: Author;
   }
   class User extends Model {
     @prop({
@@ -17,10 +25,12 @@ spec.test('returns the first model in a tree of nested models', (ctx) => {
   const user = new User({
     book: {
       title: 200,
+      author: { name: 'John' },
     },
   });
-  ctx.is(user.getRoot(), user);
-  ctx.is(user.book.getRoot(), user);
+  ctx.deepEqual(user.getAncestors(), []);
+  ctx.deepEqual(user.book.getAncestors(), [user]);
+  ctx.deepEqual(user.book.author.getAncestors(), [user, user.book]);
 });
 
 export default spec;

--- a/packages/rawmodel-core/src/tests/core/models/get-parent-instance-method.test.ts
+++ b/packages/rawmodel-core/src/tests/core/models/get-parent-instance-method.test.ts
@@ -12,11 +12,11 @@ spec.test('returns an instance of the parent model', (ctx) => {
     @prop()
     name: string;
     @prop({
-      parse: { resolver: Book },
+      parser: { resolver: Book },
     })
     book: Book;
     @prop({
-      parse: { array: true, resolver: Book },
+      parser: { array: true, resolver: Book },
     })
     books: Book[];
   }

--- a/packages/rawmodel-core/src/tests/core/models/get-prop-instance-method.test.ts
+++ b/packages/rawmodel-core/src/tests/core/models/get-prop-instance-method.test.ts
@@ -12,11 +12,11 @@ spec.test('returns an instance of a prop at path', (ctx) => {
     @prop()
     name: string;
     @prop({
-      parse: { resolver: Book },
+      parser: { resolver: Book },
     })
     book: Book;
     @prop({
-      parse: { array: true, resolver: Book },
+      parser: { array: true, resolver: Book },
     })
     books: Book[];
   }

--- a/packages/rawmodel-core/src/tests/core/models/get-root-instance-method.test.ts
+++ b/packages/rawmodel-core/src/tests/core/models/get-root-instance-method.test.ts
@@ -10,7 +10,7 @@ spec.test('returns the first model in a tree of nested models', (ctx) => {
   }
   class User extends Model {
     @prop({
-      parse: { resolver: Book },
+      parser: { resolver: Book },
     })
     book: Book;
   }

--- a/packages/rawmodel-core/src/tests/core/models/handle-instance-method.test.ts
+++ b/packages/rawmodel-core/src/tests/core/models/handle-instance-method.test.ts
@@ -4,13 +4,13 @@ import { Model, prop } from '../../..';
 const spec = new Spec();
 
 spec.test('handles property errors', async (ctx) => {
-  const handle = [{
+  const handlers = [{
     resolver: (e) => e.message === 'foo',
     code: 100,
   }];
   class Book extends Model {
     @prop({
-      handle
+      handlers
     })
     title: string;
   }
@@ -20,29 +20,29 @@ spec.test('handles property errors', async (ctx) => {
   }
   class User extends Model {
     @prop({
-      handle
+      handlers
     })
     name: string;
     @prop({
-      handle,
-      parse: { resolver: Book },
+      handlers,
+      parser: { resolver: Book },
     })
     book0: Book;
     @prop({
-      handle,
-      parse: { array: true, resolver: Book },
+      handlers,
+      parser: { array: true, resolver: Book },
     })
     books0: Book[];
     @prop({
-      parse: { resolver: Book },
+      parser: { resolver: Book },
     })
     book1: Book;
     @prop({
-      parse: { array: true, resolver: Book },
+      parser: { array: true, resolver: Book },
     })
     books1: Book[];
     @prop({
-      parse: { resolver: Country },
+      parser: { resolver: Country },
     })
     country: Country;
   }

--- a/packages/rawmodel-core/src/tests/core/models/invalidate-instance-method.test.ts
+++ b/packages/rawmodel-core/src/tests/core/models/invalidate-instance-method.test.ts
@@ -12,11 +12,11 @@ spec.test('clears property errors', async (ctx) => {
     @prop()
     name: string;
     @prop({
-      parse: { resolver: Book },
+      parser: { resolver: Book },
     })
     book: Book;
     @prop({
-      parse: { array: true, resolver: Book },
+      parser: { array: true, resolver: Book },
     })
     books: Book[];
   }

--- a/packages/rawmodel-core/src/tests/core/models/is-changed-instance-method.test.ts
+++ b/packages/rawmodel-core/src/tests/core/models/is-changed-instance-method.test.ts
@@ -12,11 +12,11 @@ spec.test('returns `true` if at least one prop has been changed', (ctx) => {
     @prop()
     name: string;
     @prop({
-      parse: { resolver: Book },
+      parser: { resolver: Book },
     })
     book: Book;
     @prop({
-      parse: { array: true, resolver: Book },
+      parser: { array: true, resolver: Book },
     })
     books: Book[];
   }

--- a/packages/rawmodel-core/src/tests/core/models/is-equal-instance-method.test.ts
+++ b/packages/rawmodel-core/src/tests/core/models/is-equal-instance-method.test.ts
@@ -12,11 +12,11 @@ spec.test('returns `true` when the passing object looks the same', (ctx) => {
     @prop()
     name: string;
     @prop({
-      parse: { resolver: Book },
+      parser: { resolver: Book },
     })
     book: Book;
     @prop({
-      parse: { array: true, resolver: Book },
+      parser: { array: true, resolver: Book },
     })
     books: Book[];
   }

--- a/packages/rawmodel-core/src/tests/core/models/is-valid-instance-method.test.ts
+++ b/packages/rawmodel-core/src/tests/core/models/is-valid-instance-method.test.ts
@@ -12,11 +12,11 @@ spec.test('tell if model has no errors', async (ctx) => {
     @prop()
     name: string;
     @prop({
-      parse: { resolver: Book },
+      parser: { resolver: Book },
     })
     book: Book;
     @prop({
-      parse: { array: true, resolver: Book },
+      parser: { array: true, resolver: Book },
     })
     books: Book[];
   }

--- a/packages/rawmodel-core/src/tests/core/models/populate-instance-method.test.ts
+++ b/packages/rawmodel-core/src/tests/core/models/populate-instance-method.test.ts
@@ -7,46 +7,46 @@ const spec = new Spec();
 spec.test('deeply assignes property data using strategies', (ctx) => {
   class Book extends Model {
     @prop({
-      parse: { resolver: floatParser() },
+      parser: { resolver: floatParser() },
       populatable: ['output'],
     })
     id: number;
     @prop({
-      parse: { resolver: stringParser() },
+      parser: { resolver: stringParser() },
     })
     title: string;
     @prop({
-      parse: { resolver: stringParser() },
+      parser: { resolver: stringParser() },
       populatable: ['input'],
     })
     description: string;
   }
   class User extends Model {
     @prop({
-      parse: { resolver: floatParser() },
+      parser: { resolver: floatParser() },
       populatable: ['output'],
     })
     id: number;
     @prop({
-      parse: { resolver: stringParser() },
+      parser: { resolver: stringParser() },
     })
     name: string;
     @prop({
-      parse: { resolver: stringParser() },
+      parser: { resolver: stringParser() },
       populatable: ['input'],
     })
     email: string;
     @prop({
-      parse: { resolver: Book },
+      parser: { resolver: Book },
       populatable: ['output'],
     })
     book0: Book;
     @prop({
-      parse: { resolver: Book },
+      parser: { resolver: Book },
     })
     book1: Book;
     @prop({
-      parse: { array: true, resolver: Book },
+      parser: { array: true, resolver: Book },
       populatable: ['input'],
     })
     books: Book[];

--- a/packages/rawmodel-core/src/tests/core/models/populate-instance-method.test.ts
+++ b/packages/rawmodel-core/src/tests/core/models/populate-instance-method.test.ts
@@ -112,4 +112,33 @@ spec.test('deeply assignes property data using strategies', (ctx) => {
   ctx.is(user3.books[0], book); // preserves instance
 });
 
+spec.test('ignores not enumerable properties', (ctx) => {
+  class Book extends Model {
+    @prop({ enumerable: false })
+    id: number;
+    @prop()
+    name: number;
+  }
+  class User extends Model {
+    @prop({ enumerable: false })
+    id: number;
+    @prop()
+    name: number;
+    @prop({
+      parser: { resolver: Book },
+    })
+    book: Book;
+  }
+  const data = {
+    id: 100,
+    name: 'John',
+    book: { id: 200, name: 'Smith' },
+  };
+  const user = new User();
+  user.populate(data);
+  ctx.is(user.id, null);
+  ctx.is(user.name, 'John');
+  ctx.is(user.book.id, null);
+});
+
 export default spec;

--- a/packages/rawmodel-core/src/tests/core/models/prop-decorator.test.ts
+++ b/packages/rawmodel-core/src/tests/core/models/prop-decorator.test.ts
@@ -43,25 +43,25 @@ spec.test('supports property enumerable style', (ctx) => {
 spec.test('supports deep type parsing', (ctx) => {
   class Book extends Model {
     @prop({
-      parse: { resolver: stringParser() },
+      parser: { resolver: stringParser() },
     })
     name: string;
   }
   class User extends Model {
     @prop({
-      parse: { resolver: stringParser() },
+      parser: { resolver: stringParser() },
     })
     name: string;
     @prop({
-      parse: { resolver: Book },
+      parser: { resolver: Book },
     })
     book: Book;
     @prop({
-      parse: { array: true, resolver: Book },
+      parser: { array: true, resolver: Book },
     })
     books: Book[];
     @prop({
-      parse: { array: true },
+      parser: { array: true },
     })
     items: any[];
   }
@@ -94,7 +94,7 @@ spec.test('parser shares associated model context', (ctx) => {
   let context = null;
   class User extends Model {
     @prop({
-      parse: { resolver(v) { context = this; return v; } },
+      parser: { resolver(v) { context = this; return v; } },
     })
     name: string;
   }
@@ -106,7 +106,7 @@ spec.test('parser shares associated model context', (ctx) => {
 spec.test('supports custom setter', (ctx) => {
   class User extends Model {
     @prop({
-      set: (v) => `foo-${v}`,
+      setter: (v) => `foo-${v}`,
     })
     name: string;
   }
@@ -119,7 +119,7 @@ spec.test('setter shares associated model context', (ctx) => {
   let context = null;
   class User extends Model {
     @prop({
-      set() { context = this; },
+      setter() { context = this; },
     })
     name: string;
   }
@@ -131,7 +131,7 @@ spec.test('setter shares associated model context', (ctx) => {
 spec.test('supports custom getter', (ctx) => {
   class User extends Model {
     @prop({
-      get: (v) => `foo-${v}`,
+      getter: (v) => `foo-${v}`,
     })
     name: string;
   }
@@ -144,7 +144,7 @@ spec.test('getter shares associated model context', (ctx) => {
   let context = null;
   class User extends Model {
     @prop({
-      get() { context = this; },
+      getter() { context = this; },
     })
     name: string;
   }
@@ -254,7 +254,7 @@ spec.test('validators share associated model context', async (ctx) => {
   let context = null;
   class User extends Model {
     @prop({
-      validate: [
+      validators: [
         { resolver(v) { return context = this; }, code: 100 },
       ],
     })
@@ -269,7 +269,7 @@ spec.test('resolvers share associated model context', async (ctx) => {
   let context = null;
   class User extends Model {
     @prop({
-      handle: [
+      handlers: [
         { resolver(v) { return context = this; }, code: 100 },
       ],
     })

--- a/packages/rawmodel-core/src/tests/core/models/reset-instance-method.test.ts
+++ b/packages/rawmodel-core/src/tests/core/models/reset-instance-method.test.ts
@@ -16,12 +16,12 @@ spec.test('sets properties to their default values', (ctx) => {
     })
     name: string;
     @prop({
-      parse: { resolver: Book },
+      parser: { resolver: Book },
       defaultValue: {},
     })
     book: Book;
     @prop({
-      parse: { array: true, resolver: Book },
+      parser: { array: true, resolver: Book },
       defaultValue: [null, {}],
     })
     books: Book[];

--- a/packages/rawmodel-core/src/tests/core/models/rollback-instance-method.test.ts
+++ b/packages/rawmodel-core/src/tests/core/models/rollback-instance-method.test.ts
@@ -12,11 +12,11 @@ spec.test('manage committed states', (ctx) => {
     @prop()
     name: string;
     @prop({
-      parse: { resolver: Book },
+      parser: { resolver: Book },
     })
     book: Book;
     @prop({
-      parse: { array: true, resolver: Book },
+      parser: { array: true, resolver: Book },
     })
     books: Book[];
   }

--- a/packages/rawmodel-core/src/tests/core/models/serialize-instance-method.test.ts
+++ b/packages/rawmodel-core/src/tests/core/models/serialize-instance-method.test.ts
@@ -7,46 +7,46 @@ const spec = new Spec();
 spec.test('deeply serializes property data using strategies', (ctx) => {
   class Book extends Model {
     @prop({
-      parse: { resolver: floatParser() },
+      parser: { resolver: floatParser() },
     })
     id: number;
     @prop({
-      parse: { resolver: stringParser() },
+      parser: { resolver: stringParser() },
       serializable: ['output'],
     })
     title: string;
     @prop({
-      parse: { resolver: stringParser() },
+      parser: { resolver: stringParser() },
       serializable: ['input'],
     })
     description: string;
   }
   class User extends Model {
     @prop({
-      parse: { resolver: floatParser() },
+      parser: { resolver: floatParser() },
       serializable: ['output'],
     })
     id: number;
     @prop({
-      parse: { resolver: stringParser() },
+      parser: { resolver: stringParser() },
     })
     name: string;
     @prop({
-      parse: { resolver: stringParser() },
+      parser: { resolver: stringParser() },
       serializable: ['input'],
     })
     email: string;
     @prop({
-      parse: { resolver: Book },
+      parser: { resolver: Book },
       serializable: ['output'],
     })
     book0: Book;
     @prop({
-      parse: { resolver: Book },
+      parser: { resolver: Book },
     })
     book1: Book;
     @prop({
-      parse: { array: true, resolver: Book },
+      parser: { array: true, resolver: Book },
       serializable: ['input'],
     })
     books: Book[];

--- a/packages/rawmodel-core/src/tests/core/models/serialize-instance-method.test.ts
+++ b/packages/rawmodel-core/src/tests/core/models/serialize-instance-method.test.ts
@@ -90,4 +90,37 @@ spec.test('deeply serializes property data using strategies', (ctx) => {
   });
 });
 
+spec.test('ignores not enumerable properties', (ctx) => {
+  class Book extends Model {
+    @prop({ enumerable: false })
+    id: number;
+    @prop()
+    name: number;
+  }
+  class User extends Model {
+    @prop({ enumerable: false })
+    id: number;
+    @prop()
+    name: number;
+    @prop({
+      parser: { resolver: Book },
+    })
+    book: Book;
+  }
+  const data = {
+    id: 100,
+    name: 'John',
+    book: { id: 200, name: 'Smith' },
+  };
+  const user = new User(data);
+  console.log(user.serialize());
+
+  ctx.deepEqual(user.serialize(), {
+    name: 'John',
+    book: {
+      name: 'Smith',
+    },
+  });
+});
+
 export default spec;

--- a/packages/rawmodel-core/src/tests/core/models/speed.test.ts
+++ b/packages/rawmodel-core/src/tests/core/models/speed.test.ts
@@ -7,68 +7,68 @@ const spec = new Spec();
 spec.test('creation of ~5k models', (ctx) => {
   class Author extends Model {
     @prop({
-      parse: { resolver: floatParser() },
+      parser: { resolver: floatParser() },
       serializable: ['output'],
     })
     id: number;
     @prop({
-      parse: { resolver: stringParser() },
+      parser: { resolver: stringParser() },
       serializable: ['output'],
     })
     name: string;
     @prop({
-      parse: { resolver: stringParser() },
+      parser: { resolver: stringParser() },
       populatable: ['input'],
     })
     email: string;
   }
   class Book extends Model {
     @prop({
-      parse: { resolver: floatParser() },
+      parser: { resolver: floatParser() },
       serializable: ['output'],
     })
     id: number;
     @prop({
-      parse: { resolver: stringParser() },
+      parser: { resolver: stringParser() },
     })
     title: string;
     @prop({
-      parse: { resolver: stringParser() },
+      parser: { resolver: stringParser() },
       populatable: ['input'],
     })
     description: string;
     @prop({
-      parse: { array: true, resolver: Author },
+      parser: { array: true, resolver: Author },
       populatable: ['input'],
     })
     author: Author[];
   }
   class User extends Model {
     @prop({
-      parse: { resolver: floatParser() },
+      parser: { resolver: floatParser() },
       serializable: ['output'],
     })
     id: number;
     @prop({
-      parse: { resolver: stringParser() },
+      parser: { resolver: stringParser() },
       serializable: ['output'],
     })
     name: string;
     @prop({
-      parse: { resolver: stringParser() },
+      parser: { resolver: stringParser() },
       populatable: ['input'],
     })
     email: string;
     @prop({
-      parse: { resolver: Book },
+      parser: { resolver: Book },
     })
     book0: Book;
     @prop({
-      parse: { resolver: Book },
+      parser: { resolver: Book },
     })
     book1: Book;
     @prop({
-      parse: { array: true, resolver: Book },
+      parser: { array: true, resolver: Book },
       populatable: ['input'],
     })
     books: Book[];

--- a/packages/rawmodel-core/src/tests/core/models/validate-instance-method.test.ts
+++ b/packages/rawmodel-core/src/tests/core/models/validate-instance-method.test.ts
@@ -4,39 +4,39 @@ import { Model, prop } from '../../..';
 const spec = new Spec();
 
 spec.test('validates properties or throws on error', async (ctx) => {
-  const validate = [
+  const validators = [
     { resolver: (v) => true, code: 100 },
     { resolver: (v) => !!v, code: 200 },
   ];
   class Book extends Model {
     @prop({
-      validate,
+      validators,
     })
     title: string;
   }
   class User extends Model {
     @prop({
-      validate,
+      validators,
     })
     name: string;
     @prop({
-      parse: { resolver: Book },
-      validate,
+      parser: { resolver: Book },
+      validators,
     })
     book0: Book;
     @prop({
-      parse: { array: true, resolver: Book },
-      validate,
+      parser: { array: true, resolver: Book },
+      validators,
     })
     books0: Book[];
     @prop({
-      parse: { resolver: Book },
-      validate,
+      parser: { resolver: Book },
+      validators,
     })
     book1: Book;
     @prop({
-      parse: { array: true, resolver: Book },
-      validate,
+      parser: { array: true, resolver: Book },
+      validators,
     })
     books1: Book[];
   }
@@ -57,7 +57,7 @@ spec.test('validates properties or throws on error', async (ctx) => {
 });
 
 spec.test('validates polymorphic arrays', async (ctx) => {
-  const validate = [
+  const validators = [
     { resolver: (v) => !!v, code: 100 },
   ];
   const parser = (v) => {
@@ -69,14 +69,14 @@ spec.test('validates polymorphic arrays', async (ctx) => {
   };
   class Book extends Model {
     @prop({
-      validate,
+      validators,
     })
     title: string;
   }
   class User extends Model {
     @prop({
-      parse: { array: true, resolver: parser },
-      validate,
+      parser: { array: true, resolver: parser },
+      validators,
     })
     books: Book[];
   }

--- a/packages/rawmodel-core/src/tests/core/props/class-config.test.ts
+++ b/packages/rawmodel-core/src/tests/core/props/class-config.test.ts
@@ -31,7 +31,7 @@ spec.test('supports empty value', (ctx) => {
 
 spec.test('supports custom getter', (ctx) => {
   const prop = new Prop({
-    get: (v) => `foo-${v}`,
+    getter: (v) => `foo-${v}`,
   });
   ctx.is(prop.getValue(), `foo-null`);
   prop.setValue('bar');
@@ -40,7 +40,7 @@ spec.test('supports custom getter', (ctx) => {
 
 spec.test('supports custom setter', (ctx) => {
   const prop = new Prop({
-    set: (v) => `foo-${v}`,
+    setter: (v) => `foo-${v}`,
   });
   ctx.is(prop.getValue(), null);
   prop.setValue('bar');

--- a/packages/rawmodel-core/src/tests/core/props/handle-instance-method.test.ts
+++ b/packages/rawmodel-core/src/tests/core/props/handle-instance-method.test.ts
@@ -5,7 +5,7 @@ const spec = new Spec();
 
 spec.test('handles property errors and populates error codes', async (ctx) => {
   const prop = new Prop({
-    handle: [
+    handlers: [
       { code: 400, resolver: (e) => e === 'foo' },
       { code: 401, resolver: (e) => e === 'foo' },
     ],

--- a/packages/rawmodel-core/src/tests/core/props/is-valid-instance-method.test.ts
+++ b/packages/rawmodel-core/src/tests/core/props/is-valid-instance-method.test.ts
@@ -16,7 +16,7 @@ spec.test('returns true if the property has no errors', (ctx) => {
   prop0.setErrorCode(null);
   prop0.setValue(user);
   ctx.true(prop0.isValid());
-  prop0.$config.parse = { resolver: User }; // nested model type
+  prop0.$config.parser = { resolver: User }; // nested model type
   user.getProp('name').setErrorCode(200); // nested model error
   ctx.false(prop0.isValid());
 });

--- a/packages/rawmodel-core/src/tests/core/props/set-value-instance-method.test.ts
+++ b/packages/rawmodel-core/src/tests/core/props/set-value-instance-method.test.ts
@@ -17,7 +17,7 @@ spec.test('sets property value', (ctx) => {
 
 spec.test('parses input data', (ctx) => {
   const prop = new Prop({
-    parse: { resolver: integerParser() },
+    parser: { resolver: integerParser() },
   });
   prop.setValue('100');
   ctx.is(prop.getValue(), 100);

--- a/packages/rawmodel-core/src/tests/core/props/validate-instance-method.test.ts
+++ b/packages/rawmodel-core/src/tests/core/props/validate-instance-method.test.ts
@@ -5,7 +5,7 @@ const spec = new Spec();
 
 spec.test('validates property and populates error codes', async (ctx) => {
   const prop = new Prop({
-    validate: [
+    validators: [
       { code: 400, resolver: (v) => true },
       { code: 401, resolver: (v) => false },
     ],

--- a/packages/rawmodel-handlers/CHANGELOG.json
+++ b/packages/rawmodel-handlers/CHANGELOG.json
@@ -2,6 +2,12 @@
   "name": "@rawmodel/handlers",
   "entries": [
     {
+      "version": "3.3.0",
+      "tag": "@rawmodel/handlers_v3.3.0",
+      "date": "Thu, 03 Oct 2019 15:49:09 GMT",
+      "comments": {}
+    },
+    {
       "version": "3.2.1",
       "tag": "@rawmodel/handlers_v3.2.1",
       "date": "Sun, 29 Sep 2019 10:22:42 GMT",

--- a/packages/rawmodel-handlers/CHANGELOG.md
+++ b/packages/rawmodel-handlers/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log - @rawmodel/handlers
 
-This log was last generated on Sun, 29 Sep 2019 10:22:42 GMT and should not be manually modified.
+This log was last generated on Thu, 03 Oct 2019 15:49:09 GMT and should not be manually modified.
+
+## 3.3.0
+Thu, 03 Oct 2019 15:49:09 GMT
+
+*Version update only*
 
 ## 3.2.1
 Sun, 29 Sep 2019 10:22:42 GMT

--- a/packages/rawmodel-handlers/package.json
+++ b/packages/rawmodel-handlers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rawmodel/handlers",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "description": "Collection of error handlers for RawModel.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/rawmodel-parsers/CHANGELOG.json
+++ b/packages/rawmodel-parsers/CHANGELOG.json
@@ -2,6 +2,12 @@
   "name": "@rawmodel/parsers",
   "entries": [
     {
+      "version": "3.3.0",
+      "tag": "@rawmodel/parsers_v3.3.0",
+      "date": "Thu, 03 Oct 2019 15:49:09 GMT",
+      "comments": {}
+    },
+    {
       "version": "3.2.1",
       "tag": "@rawmodel/parsers_v3.2.1",
       "date": "Sun, 29 Sep 2019 10:22:42 GMT",

--- a/packages/rawmodel-parsers/CHANGELOG.md
+++ b/packages/rawmodel-parsers/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log - @rawmodel/parsers
 
-This log was last generated on Sun, 29 Sep 2019 10:22:42 GMT and should not be manually modified.
+This log was last generated on Thu, 03 Oct 2019 15:49:09 GMT and should not be manually modified.
+
+## 3.3.0
+Thu, 03 Oct 2019 15:49:09 GMT
+
+*Version update only*
 
 ## 3.2.1
 Sun, 29 Sep 2019 10:22:42 GMT

--- a/packages/rawmodel-parsers/package.json
+++ b/packages/rawmodel-parsers/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rawmodel/parsers",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "description": "Collection of data parsers for RawModel.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -91,6 +91,6 @@
     "typescript": "^3.5.3"
   },
   "dependencies": {
-    "@rawmodel/utils": "3.2.1"
+    "@rawmodel/utils": "3.3.0"
   }
 }

--- a/packages/rawmodel-schema/CHANGELOG.json
+++ b/packages/rawmodel-schema/CHANGELOG.json
@@ -2,6 +2,12 @@
   "name": "@rawmodel/schema",
   "entries": [
     {
+      "version": "3.3.0",
+      "tag": "@rawmodel/schema_v3.3.0",
+      "date": "Thu, 03 Oct 2019 15:49:09 GMT",
+      "comments": {}
+    },
+    {
       "version": "3.2.1",
       "tag": "@rawmodel/schema_v3.2.1",
       "date": "Sun, 29 Sep 2019 10:22:42 GMT",

--- a/packages/rawmodel-schema/CHANGELOG.md
+++ b/packages/rawmodel-schema/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log - @rawmodel/schema
 
-This log was last generated on Sun, 29 Sep 2019 10:22:42 GMT and should not be manually modified.
+This log was last generated on Thu, 03 Oct 2019 15:49:09 GMT and should not be manually modified.
+
+## 3.3.0
+Thu, 03 Oct 2019 15:49:09 GMT
+
+*Version update only*
 
 ## 3.2.1
 Sun, 29 Sep 2019 10:22:42 GMT

--- a/packages/rawmodel-schema/package.json
+++ b/packages/rawmodel-schema/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rawmodel/schema",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "description": "JSON Schema utils for RawModel.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -84,16 +84,16 @@
   "devDependencies": {
     "@hayspec/cli": "^0.8.4",
     "@hayspec/spec": "^0.8.4",
-    "@rawmodel/handlers": "3.2.1",
-    "@rawmodel/parsers": "3.2.1",
-    "@rawmodel/validators": "3.2.1",
+    "@rawmodel/handlers": "3.3.0",
+    "@rawmodel/parsers": "3.3.0",
+    "@rawmodel/validators": "3.3.0",
     "nyc": "^14.1.1",
     "ts-node": "^8.3.0",
     "tslint": "^5.18.0",
     "typescript": "^3.5.3"
   },
   "dependencies": {
-    "@rawmodel/core": "3.2.1",
-    "@rawmodel/utils": "3.2.1"
+    "@rawmodel/core": "3.3.0",
+    "@rawmodel/utils": "3.3.0"
   }
 }

--- a/packages/rawmodel-schema/src/core/builder.ts
+++ b/packages/rawmodel-schema/src/core/builder.ts
@@ -30,8 +30,8 @@ export function createModelClass(recipe: SchemaRecipe): typeof Model {
 
   (recipe.props || []).forEach((prop) => {
     const obj: any = {
-      set: undefined,
-      get: undefined,
+      setter: undefined,
+      getter: undefined,
       populatable: prop.populatable,
       serializable: prop.serializable,
       enumerable: prop.enumerable,

--- a/packages/rawmodel-schema/src/core/builder.ts
+++ b/packages/rawmodel-schema/src/core/builder.ts
@@ -35,16 +35,16 @@ export function createModelClass(recipe: SchemaRecipe): typeof Model {
       populatable: prop.populatable,
       serializable: prop.serializable,
       enumerable: prop.enumerable,
-      parse: {},
-      validate: [],
-      handle: [],
+      parser: {},
+      validators: [],
+      handlers: [],
     };
 
-    if (!isUndefined(prop.get) && isFunction(recipe.getters[prop.get])) {
-      obj.get = recipe.getters[prop.get]();
+    if (!isUndefined(prop.getter) && isFunction(recipe.getters[prop.getter])) {
+      obj.getter = recipe.getters[prop.getter]();
     }
-    if (!isUndefined(prop.set) && isFunction(recipe.setters[prop.set])) {
-      obj.set = recipe.setters[prop.set]();
+    if (!isUndefined(prop.setter) && isFunction(recipe.setters[prop.setter])) {
+      obj.setter = recipe.setters[prop.setter]();
     }
 
     if (!isUndefined(prop.defaultValue)) {
@@ -63,25 +63,25 @@ export function createModelClass(recipe: SchemaRecipe): typeof Model {
         : prop.emptyValue;
     }
 
-    if (!isUndefined(prop.parse)) {
-      obj.parse.array = !!prop.parse.array;
-      if (prop.parse.resolver && isFunction(recipe.parsers[prop.parse.resolver])) {
-        obj.parse.resolver = recipe.parsers[prop.parse.resolver](prop.parse.options);
+    if (!isUndefined(prop.parser)) {
+      obj.parser.array = !!prop.parser.array;
+      if (prop.parser.resolver && isFunction(recipe.parsers[prop.parser.resolver])) {
+        obj.parser.resolver = recipe.parsers[prop.parser.resolver](prop.parser.options);
       }
     }
 
-    (prop.validate || []).forEach((validator) => {
+    (prop.validators || []).forEach((validator) => {
       if (isFunction(recipe.validators[validator.resolver])) {
-        obj.validate.push({
+        obj.validators.push({
           ...validator,
           resolver: recipe.validators[validator.resolver](validator.options),
         });
       }
     });
 
-    (prop.handle || []).forEach((handler) => {
+    (prop.handlers || []).forEach((handler) => {
       if (isFunction(recipe.handlers[handler.resolver])) {
-        obj.handle.push({
+        obj.handlers.push({
           ...handler,
           resolver: recipe.handlers[handler.resolver](handler.options),
         });

--- a/packages/rawmodel-schema/src/core/types.ts
+++ b/packages/rawmodel-schema/src/core/types.ts
@@ -21,14 +21,14 @@ export interface SchemaRecipe {
  */
 export interface PropDefinition {
   name: string;
-  set?: string;
-  get?: string;
-  parse?: ParserRecipe;
+  setter?: string;
+  getter?: string;
+  parser?: ParserRecipe;
   defaultValue?: string;
   fakeValue?: string;
   emptyValue?: string;
-  validate?: ValidatorRecipe[];
-  handle?: HandlerRecipe[];
+  validators?: ValidatorRecipe[];
+  handlers?: HandlerRecipe[];
   populatable?: string[];
   serializable?: string[];
   enumerable?: boolean;

--- a/packages/rawmodel-schema/src/tests/core/builder/create-model-method.test.ts
+++ b/packages/rawmodel-schema/src/tests/core/builder/create-model-method.test.ts
@@ -34,7 +34,7 @@ spec.test('supports property custom getter', (ctx) => {
     props: [
       {
         name: 'firstName',
-        get: 'foo',
+        getter: 'foo',
       },
     ],
   });
@@ -52,7 +52,7 @@ spec.test('supports property custom setter', (ctx) => {
     props: [
       {
         name: 'firstName',
-        set: 'foo',
+        setter: 'foo',
       },
     ],
   });
@@ -141,7 +141,7 @@ spec.test('supports property parsers', (ctx) => {
     props: [
       {
         name: 'firstName',
-        parse: {
+        parser: {
           array: true,
           resolver: 'string',
         },
@@ -164,7 +164,7 @@ spec.test('supports property validators', async (ctx) => {
     props: [
       {
         name: 'firstName',
-        validate: [
+        validators: [
           {
             resolver: 'stringLength',
             code: 400,
@@ -191,7 +191,7 @@ spec.test('supports property handlers', async (ctx) => {
     props: [
       {
         name: 'firstName',
-        handle: [
+        handlers: [
           {
             resolver: 'generalError',
             code: 400,

--- a/packages/rawmodel-utils/CHANGELOG.json
+++ b/packages/rawmodel-utils/CHANGELOG.json
@@ -2,6 +2,12 @@
   "name": "@rawmodel/utils",
   "entries": [
     {
+      "version": "3.3.0",
+      "tag": "@rawmodel/utils_v3.3.0",
+      "date": "Thu, 03 Oct 2019 15:49:09 GMT",
+      "comments": {}
+    },
+    {
       "version": "3.2.1",
       "tag": "@rawmodel/utils_v3.2.1",
       "date": "Sun, 29 Sep 2019 10:22:42 GMT",

--- a/packages/rawmodel-utils/CHANGELOG.md
+++ b/packages/rawmodel-utils/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log - @rawmodel/utils
 
-This log was last generated on Sun, 29 Sep 2019 10:22:42 GMT and should not be manually modified.
+This log was last generated on Thu, 03 Oct 2019 15:49:09 GMT and should not be manually modified.
+
+## 3.3.0
+Thu, 03 Oct 2019 15:49:09 GMT
+
+*Version update only*
 
 ## 3.2.1
 Sun, 29 Sep 2019 10:22:42 GMT

--- a/packages/rawmodel-utils/package.json
+++ b/packages/rawmodel-utils/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rawmodel/utils",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "description": "Helper functions for RawModel.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",

--- a/packages/rawmodel-validators/CHANGELOG.json
+++ b/packages/rawmodel-validators/CHANGELOG.json
@@ -2,6 +2,12 @@
   "name": "@rawmodel/validators",
   "entries": [
     {
+      "version": "3.3.0",
+      "tag": "@rawmodel/validators_v3.3.0",
+      "date": "Thu, 03 Oct 2019 15:49:09 GMT",
+      "comments": {}
+    },
+    {
       "version": "3.2.1",
       "tag": "@rawmodel/validators_v3.2.1",
       "date": "Sun, 29 Sep 2019 10:22:42 GMT",

--- a/packages/rawmodel-validators/CHANGELOG.md
+++ b/packages/rawmodel-validators/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log - @rawmodel/validators
 
-This log was last generated on Sun, 29 Sep 2019 10:22:42 GMT and should not be manually modified.
+This log was last generated on Thu, 03 Oct 2019 15:49:09 GMT and should not be manually modified.
+
+## 3.3.0
+Thu, 03 Oct 2019 15:49:09 GMT
+
+*Version update only*
 
 ## 3.2.1
 Sun, 29 Sep 2019 10:22:42 GMT

--- a/packages/rawmodel-validators/package.json
+++ b/packages/rawmodel-validators/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rawmodel/validators",
-  "version": "3.2.1",
+  "version": "3.3.0",
   "description": "Collection of validators for RawModel.",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -91,6 +91,6 @@
     "typescript": "^3.5.3"
   },
   "dependencies": {
-    "@rawmodel/utils": "3.2.1"
+    "@rawmodel/utils": "3.3.0"
   }
 }


### PR DESCRIPTION
- Renaming `@prop` interface properties.
- Upgrade model's `getRoot` method to `getAncestors`.
- Only `enumerable` properties are not populatable and serializable.